### PR TITLE
Updated default Util.RelationshipEdge toString return.

### DIFF
--- a/src/main/java/util/RelationshipEdge.java
+++ b/src/main/java/util/RelationshipEdge.java
@@ -102,8 +102,8 @@ public class RelationshipEdge extends DefaultEdge {
 		if (o == null) { // analisa se este eh nulo. se for...
 			return ("{" + getSource() + "," + getTarget() + "}"); // retorna uma representacao no formato "{v1,v2}"
 		} else // caso contrario...
-			//return (att.get("label")).toString() + "->{" + getSource() + "," + getTarget() + "}"; // retorna uma representacao no formato "label->{v1,v2}"
-			return o.toString();
+			return (att.get("label")).toString() + "->{" + getSource() + "," + getTarget() + "}"; // retorna uma representacao no formato "label->{v1,v2}"
+			//return o.toString();
 	}
 	
 	public String toStringAtt() {


### PR DESCRIPTION
This allow a correct visualization of the label in edge set.

I assume this should be set by default for labs' activities.